### PR TITLE
多项目窗口支持

### DIFF
--- a/src-tauri/capabilities/project-window.json
+++ b/src-tauri/capabilities/project-window.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
-  "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": ["main"],
+  "identifier": "project-window",
+  "description": "Capability for project windows",
+  "windows": ["project-*"],
   "permissions": [
     "core:default",
     "opener:default",
@@ -27,7 +27,6 @@
     "fs:allow-appdata-write-recursive",
     "clipboard-manager:default",
     "clipboard-manager:allow-read-text",
-    "clipboard-manager:allow-write-text",
-    "core:webview:allow-create-webview-window"
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -1,4 +1,5 @@
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
+use crate::AppState;
 
 #[tauri::command]
 pub async fn show_log_viewer(app: tauri::AppHandle) -> Result<(), String> {
@@ -22,4 +23,36 @@ pub async fn show_log_viewer(app: tauri::AppHandle) -> Result<(), String> {
     }
     
     Ok(())
+}
+
+#[tauri::command]
+pub async fn open_project_window(
+    project_id: String,
+    project_name: String,
+    state: State<'_, AppState>
+) -> Result<String, String> {
+    state.window_manager.open_project_window(&project_id, &project_name).await
+}
+
+#[tauri::command]
+pub async fn close_project_window(
+    project_id: String,
+    state: State<'_, AppState>
+) -> Result<(), String> {
+    state.window_manager.close_project_window(&project_id).await
+}
+
+#[tauri::command]
+pub async fn get_project_window(
+    project_id: String,
+    state: State<'_, AppState>
+) -> Result<Option<String>, String> {
+    Ok(state.window_manager.get_project_window(&project_id).await)
+}
+
+#[tauri::command]
+pub async fn list_open_project_windows(
+    state: State<'_, AppState>
+) -> Result<Vec<(String, String)>, String> {
+    Ok(state.window_manager.list_open_projects().await)
 }

--- a/src-tauri/src/window_manager.rs
+++ b/src-tauri/src/window_manager.rs
@@ -1,0 +1,120 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tokio::sync::Mutex;
+
+/// Manages project windows, ensuring each project has its own window
+pub struct ProjectWindowManager {
+    /// Maps project IDs to window labels
+    project_windows: Arc<Mutex<HashMap<String, String>>>,
+    app_handle: AppHandle,
+}
+
+impl ProjectWindowManager {
+    pub fn new(app_handle: AppHandle) -> Self {
+        Self {
+            project_windows: Arc::new(Mutex::new(HashMap::new())),
+            app_handle,
+        }
+    }
+
+    /// Opens a window for a project, creating a new one if it doesn't exist
+    pub async fn open_project_window(&self, project_id: &str, project_name: &str) -> Result<String, String> {
+        let mut windows = self.project_windows.lock().await;
+        
+        // Check if window already exists for this project
+        if let Some(window_label) = windows.get(project_id) {
+            // Window exists, bring it to front
+            if let Some(window) = self.app_handle.get_webview_window(window_label) {
+                window.show().map_err(|e| format!("Failed to show window: {}", e))?;
+                window.set_focus().map_err(|e| format!("Failed to focus window: {}", e))?;
+                return Ok(window_label.clone());
+            } else {
+                // Window was closed, remove from map
+                windows.remove(project_id);
+            }
+        }
+        
+        // Create new window
+        let window_label = format!("project-{}", project_id);
+        let window_title = format!("Pivo - {}", project_name);
+        
+        let window = WebviewWindowBuilder::new(
+            &self.app_handle,
+            &window_label,
+            WebviewUrl::App(format!("index.html?projectId={}", project_id).into())
+        )
+        .title(&window_title)
+        .inner_size(1440.0, 900.0)
+        .min_inner_size(1200.0, 700.0)
+        .resizable(true)
+        .build()
+        .map_err(|e| format!("Failed to create window: {}", e))?;
+        
+        // Store project ID in window state for later retrieval
+        window.eval(&format!(
+            "window.__TAURI_PROJECT_ID__ = '{}';", 
+            project_id
+        )).map_err(|e| format!("Failed to set project ID: {}", e))?;
+        
+        // Listen for window close events to clean up tracking
+        let windows_clone = self.project_windows.clone();
+        let project_id_clone = project_id.to_string();
+        window.on_window_event(move |event| {
+            if let tauri::WindowEvent::CloseRequested { .. } | tauri::WindowEvent::Destroyed = event {
+                let windows = windows_clone.clone();
+                let project_id_to_remove = project_id_clone.clone();
+                tauri::async_runtime::spawn(async move {
+                    let mut windows = windows.lock().await;
+                    windows.remove(&project_id_to_remove);
+                });
+            }
+        });
+        
+        // Add to tracking map
+        windows.insert(project_id.to_string(), window_label.clone());
+        
+        Ok(window_label)
+    }
+    
+    /// Closes a project window
+    pub async fn close_project_window(&self, project_id: &str) -> Result<(), String> {
+        let mut windows = self.project_windows.lock().await;
+        
+        if let Some(window_label) = windows.remove(project_id) {
+            if let Some(window) = self.app_handle.get_webview_window(&window_label) {
+                window.close().map_err(|e| format!("Failed to close window: {}", e))?;
+            }
+        }
+        
+        Ok(())
+    }
+    
+    /// Gets the window label for a project
+    pub async fn get_project_window(&self, project_id: &str) -> Option<String> {
+        let windows = self.project_windows.lock().await;
+        windows.get(project_id).cloned()
+    }
+    
+    /// Lists all open project windows
+    pub async fn list_open_projects(&self) -> Vec<(String, String)> {
+        let windows = self.project_windows.lock().await;
+        windows.iter().map(|(id, label)| (id.clone(), label.clone())).collect()
+    }
+    
+    /// Cleanup closed windows from tracking
+    pub async fn cleanup_closed_windows(&self) {
+        let mut windows = self.project_windows.lock().await;
+        let mut to_remove = Vec::new();
+        
+        for (project_id, window_label) in windows.iter() {
+            if self.app_handle.get_webview_window(window_label).is_none() {
+                to_remove.push(project_id.clone());
+            }
+        }
+        
+        for project_id in to_remove {
+            windows.remove(&project_id);
+        }
+    }
+}

--- a/src/features/projects/ProjectsView.tsx
+++ b/src/features/projects/ProjectsView.tsx
@@ -5,13 +5,11 @@
 import { useState, useEffect } from 'react';
 import { ProjectList } from '@/features/projects/components/ProjectList';
 import { ProjectSettingsDialog } from '@/features/projects/components/ProjectSettingsDialog';
-import { useApp } from '@/contexts/AppContext';
-import { projectApi, ProjectInfo } from '@/services/api';
+import { projectApi, ProjectInfo, windowApi } from '@/services/api';
 import { Project } from '@/types';
 import { transformGitUrl } from '@/lib/gitUrlUtils';
 
 export function ProjectsView() {
-  const { setCurrentProject, navigateTo } = useApp();
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
@@ -84,13 +82,11 @@ export function ProjectsView() {
           try {
             // Update last opened time
             await projectApi.updateLastOpened(project.id);
-            setCurrentProject(project);
-            navigateTo('tasks');
+            
+            // Open project in new window
+            await windowApi.openProjectWindow(project.id, project.name);
           } catch (error) {
-            console.error('Failed to update last opened time:', error);
-            // Still navigate even if update fails
-            setCurrentProject(project);
-            navigateTo('tasks');
+            console.error('Failed to open project window:', error);
           }
         }}
         onCreateProject={handleSelectProjectDirectory}
@@ -117,8 +113,9 @@ export function ProjectsView() {
           });
           await loadProjects();
           setSelectedProjectInfo(null);
-          setCurrentProject(project);
-          navigateTo('tasks');
+          
+          // Open project in new window
+          await windowApi.openProjectWindow(project.id, project.name);
         }}
         isCreating={true}
       />

--- a/src/services/api/WindowApi.ts
+++ b/src/services/api/WindowApi.ts
@@ -1,0 +1,25 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export class WindowApi {
+  static async openProjectWindow(projectId: string, projectName: string): Promise<string> {
+    return invoke('open_project_window', { projectId, projectName });
+  }
+
+  static async closeProjectWindow(projectId: string): Promise<void> {
+    return invoke('close_project_window', { projectId });
+  }
+
+  static async getProjectWindow(projectId: string): Promise<string | null> {
+    return invoke('get_project_window', { projectId });
+  }
+
+  static async listOpenProjectWindows(): Promise<[string, string][]> {
+    return invoke('list_open_project_windows');
+  }
+
+  static async showLogViewer(): Promise<void> {
+    return invoke('show_log_viewer');
+  }
+}
+
+export const windowApi = WindowApi;

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -12,6 +12,7 @@ export * from './LoggingApi';
 export * from './GitHubApi';
 export * from './GitLabApi';
 export * from './FileSystemApi';
+export * from './WindowApi';
 
 // Re-export commonly used services
 export { projectApi } from './ProjectApi';
@@ -23,3 +24,4 @@ export { mcpApi } from './McpApi';
 export { loggingApi } from './LoggingApi';
 export { gitHubApi } from './GitHubApi';
 export { gitLabApi } from './GitLabApi';
+export { windowApi } from './WindowApi';


### PR DESCRIPTION
在打开一个项目的时候，需要用独立的窗口来打开。而不是多个项目都在同一个窗口中进行，这样的话我们就可以支持多个项目同时进行开发。

你需要研究清楚在 Tauri2.0 上怎么实现这样基于 project 的多窗口机制，并且实现。

如果重复打开 project 的时候，如果改project 已经打开了，则把对应的窗口先是到最前就行了。
