### PR TITLE
修复 Task Conversation 中发送消息状态禁用的问题

### DIFF
--- a/src-tauri/src/commands/task_commands.rs
+++ b/src-tauri/src/commands/task_commands.rs
@@ -93,6 +93,11 @@ pub async fn get_conversation_state(
     
     // Check if task is executing and get current execution
     let executions = cli_state.service.list_executions();
+    log::debug!("Total executions found: {}", executions.len());
+    for exec in &executions {
+        log::debug!("Execution - ID: {}, Task ID: {}, Status: {:?}", exec.id, exec.task_id, exec.status);
+    }
+    
     let current_execution = executions.iter().find(|e| e.task_id == task_id).cloned();
     
     let is_executing = current_execution.as_ref().map(|e| 
@@ -101,6 +106,9 @@ pub async fn get_conversation_state(
             crate::services::coding_agent_executor::types::CodingAgentExecutionStatus::Starting
         )
     ).unwrap_or(false);
+    
+    log::info!("get_conversation_state for task {}: is_executing = {}, has_attempt = {}", 
+        task_id, is_executing, current_attempt.is_some());
     
     // Get messages from current attempt
     let messages = if let Some(attempt) = current_attempt {

--- a/src/features/tasks/conversation/TaskConversation.tsx
+++ b/src/features/tasks/conversation/TaskConversation.tsx
@@ -29,6 +29,15 @@ export const TaskConversation: React.FC<TaskConversationProps> = ({ task }) => {
   // Get state from backend
   const conversationState = useTaskConversationState(task.id);
   
+  // Debug logging
+  useEffect(() => {
+    console.log(`[TaskConversation] State for task ${task.id}:`, {
+      isExecuting: conversationState.isExecuting,
+      canSendMessage: conversationState.canSendMessage,
+      executionStatus: conversationState.isExecuting ? CodingAgentExecutionStatus.Running : undefined
+    });
+  }, [task.id, conversationState.isExecuting, conversationState.canSendMessage]);
+  
   // Commands
   const { sendMessage, stopExecution } = useTaskCommand();
   


### PR DESCRIPTION
情况描述：当多个 Task 处于运行状态的时候，我点击 Task 切换 Task 之后。即使是没有任何 coding agent 在执行的 Task 中的 Task Conversation 的下面的输入框也是禁用的状态。
预期：在切换了 Task 之后，如果 Task 中没有 coding agent 在执行，输入框应该可以输入。

你需要研究一下，为什么这里的输入框的禁用状态像是被共享了一样，看一下这里是否有架构问题。

Attached 1 images