### PR TITLE
修正任务的分支名

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3457,6 +3457,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "deunicode",
  "directories",
  "dirs 5.0.1",
  "git2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 tauri-plugin-dialog = "2.3.0"
 tauri-plugin-fs = "2.4.0"
 slug = "0.1.6"
+deunicode = "1.6"
 async-trait = "0.1.88"
 reqwest = { version = "0.12.22", features = ["json", "native-tls-vendored"] }
 lazy_static = "1.5.0"

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,6 +1,5 @@
 use crate::models::{DiffMode, DiffResult, RebaseStatus};
 use crate::services::GitService;
-use crate::utils::command::execute_git;
 use std::path::Path;
 
 // Original git commands

--- a/src-tauri/src/services/git_service.rs
+++ b/src-tauri/src/services/git_service.rs
@@ -22,7 +22,8 @@ impl GitService {
         branch_name: &str,
         base_branch: &str,
     ) -> Result<PathBuf, String> {
-        let worktree_name = branch_name;
+        // Replace slashes with dashes to create a flat directory structure
+        let worktree_name = branch_name.replace('/', "-");
         let worktree_path = self.temp_dir.join(&worktree_name);
         
         log::info!("Creating worktree for branch {} at {:?}", branch_name, worktree_path);


### PR DESCRIPTION
问题： 现在任务的分支名太长了是 task-<uuid> 的形式，并且没有什么含义。
诉求：把分支名变短，且变得有含义。

创建 worktree 的时候，需要从分支名中提取出来一个有含义的名字，并且确保不存在对应的分支。提取名字的时候需要注意，我们的分支名字都是英文的，但是用户 title 的输入可能是各种各样的语言，比如中文。所以这里需要看怎么能够从各种各样的语言中，提取出来合适的名字。看看 rust 有没有什么好用的库能够解决类似的问题。